### PR TITLE
Add clickable message cards to flower surprise page

### DIFF
--- a/sorpresa.html
+++ b/sorpresa.html
@@ -161,6 +161,67 @@
           perspective: 1000px;
         }
 
+        #flower-page {
+          position: relative;
+          width: 100%;
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: flex-end;
+          padding: 40px 20px 0;
+          gap: 24px;
+        }
+
+        .card-wrapper {
+          position: absolute;
+          top: 10vh;
+          left: 50%;
+          transform: translateX(-50%);
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+          gap: 20px;
+          max-width: 90vw;
+          z-index: 5;
+        }
+
+        .message-card {
+          background: rgba(255, 255, 255, 0.12);
+          border: 2px solid rgba(255, 255, 255, 0.2);
+          border-radius: 18px;
+          padding: 18px 24px;
+          width: clamp(220px, 26vw, 280px);
+          color: #ffffff;
+          font-family: 'Poppins', cursive;
+          text-align: center;
+          line-height: 1.4;
+          letter-spacing: 1px;
+          cursor: pointer;
+          box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+          backdrop-filter: blur(6px);
+          -webkit-backdrop-filter: blur(6px);
+          transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+        }
+
+        .message-card p {
+          margin: 0;
+          font-size: 1rem;
+        }
+
+        .message-card:focus-visible {
+          outline: 3px solid rgba(255, 215, 0, 0.85);
+          outline-offset: 4px;
+        }
+
+        .message-card:hover,
+        .message-card--active {
+          transform: translateY(-8px) scale(1.04);
+          box-shadow: 0 18px 36px rgba(255, 214, 0, 0.4);
+          border-color: rgba(255, 214, 0, 0.75);
+          background: rgba(255, 214, 0, 0.18);
+        }
+
         #lyrics {
           font-size: 28px;
           font-family: "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
@@ -176,6 +237,18 @@
               font-size: 14px;
               margin-bottom: 530px;
               letter-spacing: 3px;
+          }
+
+          .card-wrapper {
+              top: 14vh;
+              gap: 14px;
+              max-width: 95vw;
+          }
+
+          .message-card {
+              width: 88vw;
+              padding: 16px 18px;
+              font-size: 0.95rem;
           }
         }
         .titulo {
@@ -1843,6 +1916,18 @@
         traes a mi vida. <br> <br>
         Gracias por iluminar mis días con tu presencia.</h1>
 
+      <div class="card-wrapper" aria-label="Cartas con mensajes especiales">
+        <div class="message-card" role="button" tabindex="0" aria-pressed="false">
+          <p>Perdon, esta vez sera por aqui, La proxima si sera presencial.</p>
+        </div>
+        <div class="message-card" role="button" tabindex="0" aria-pressed="false">
+          <p>Eres una gran persona y amiga cachetoncita.</p>
+        </div>
+        <div class="message-card" role="button" tabindex="0" aria-pressed="false">
+          <p>Haz almorzado y me deja hacerle llamadita?</p>
+        </div>
+      </div>
+
       <div class="night"></div>
       <div class="flowers">
         <div class="flower flower--1">
@@ -2184,6 +2269,23 @@
             }, 300);
         }
         
+        const messageCards = document.querySelectorAll('.message-card');
+
+        function toggleCardSelection(card) {
+            const isActive = card.classList.toggle('message-card--active');
+            card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        }
+
+        messageCards.forEach((card) => {
+            card.addEventListener('click', () => toggleCardSelection(card));
+            card.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    toggleCardSelection(card);
+                }
+            });
+        });
+
         // Iniciar corazones flotantes
         createHearts();
 


### PR DESCRIPTION
## Summary
- add a floating trio of message cards to the flower scene with the requested phrases
- style the cards for glowing hover/active states and responsive layouts
- enable mouse and keyboard interaction that toggles the card highlight state

## Testing
- not run (HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d0971a25fc832dab55df1815bd0e30